### PR TITLE
Delete Brena_Donyld.lua

### DIFF
--- a/freportw/Brena_Donyld.lua
+++ b/freportw/Brena_Donyld.lua
@@ -1,4 +1,0 @@
-function event_trade(e)
-	local item_lib = require("items");
-	item_lib.return_items(e.self, e.other, e.trade);
-end


### PR DESCRIPTION
Delete Code for Brene Donyld - only code for do not eat item, which should be handled by a global.