### PR TITLE
Delete Brina_Foxtripper.lua

### DIFF
--- a/freportw/Brina_Foxtripper.lua
+++ b/freportw/Brina_Foxtripper.lua
@@ -1,4 +1,0 @@
-function event_trade(e)
-	local item_lib = require("items");
-	item_lib.return_items(e.self, e.other, e.trade);
-end


### PR DESCRIPTION
Delete Brina_Foxtripper.lua - this is do not eat stuff code only - handled by global