### PR TITLE
Update Krazen_Loosh.pl

### DIFF
--- a/freportw/Krazen_Loosh.pl
+++ b/freportw/Krazen_Loosh.pl
@@ -3,12 +3,6 @@ sub EVENT_SPAWN {
 	quest::SetRunning(1);
 }
 
-sub EVENT_SAY {
-	if ($text=~/hail/i) {
-		quest::say("The towering wall of stone is clearly unmovable at this point, being held in place by collection of magical energies.");
-	}
-}
-
 sub EVENT_WAYPOINT_ARRIVE {
 	if ($wp == 8) {
 		quest::say("Hello, Alayle. We just got a message from Qeynos. I think you should come with me.");
@@ -22,7 +16,7 @@ sub EVENT_WAYPOINT_ARRIVE {
 sub EVENT_SIGNAL { 
 	#:: Match a signal '1' from /freportw/Guard_Alayle.pl
 	if ($signal == 1) {
-		quest::say("As you try to open penetrate the stone wall it is clearly being held in place by a powerful force.");
+		quest::say("Oh, well. We can talk here. You just have to do all the bleeding.");
 		#:: Attack West Freeport >> Guard_Alayle (9141)
 		quest::attacknpctype(9141);
 		#:: Send a signal '1' to West Freeport >> Guard_Lithnon (9106) with no delay


### PR DESCRIPTION
Made some dialog adjustments based on Allakazam research.  The text originally listed in this quest:
Hail response "Krazen Loosh says ‘The towering wall of stone is clearly unmovable at this point, being held in place by collection of magical energies.’
Response to: Guard Alayle says ‘Oh no!! It is too late!! Run!!’:
Krazen Loosh says ‘As you try to open penetrate the stone wall it is clearly being held in place by a powerful force.’

These appear to have been captured emotes that may have been triggered related to another action or quest.  I did find a documented response to Guard Alayle's "run": Oh, well. We can talk here. You just have to do all the bleeding So i added that. 

I deleted the hail dialog all together.  My reasoning is that the response did not make sense, Krazen is a triggered spawn not listed for other quests, and it makes sense that he would ignore all others and be moving to beat up the Traitor.   I think the result is a cleaner interaction with the NPC.