### PR TITLE
Update Groflah_Steadirt.pl

### DIFF
--- a/freporte/Groflah_Steadirt.pl
+++ b/freporte/Groflah_Steadirt.pl
@@ -20,8 +20,8 @@ sub EVENT_ITEM {
 	#:: Match a 18818 - Tattered Flier
 	if (plugin::takeItems(18818 => 1)) {
 		quest::say("This used to be hanging in Zimel's Blades. It is the price list. It is badly faded though. There was a fire in Zimel's Blades and I was on the scene just afterward. I did not see this hanging. I wonder who took it . . . Hmmmm.. oh, yes.. the markings on the list! It is a code! Here. I will fill it in. Read it. You probably do not even know who [Ariska] is.");
-		#:: Give item 18818 - Tattered Flier
-		quest::summonitem(18818);
+		#:: Give item 18819 - Tattered Flier
+		quest::summonitem(18819);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions


### PR DESCRIPTION
This is the Groflah that should give you tattered flier 18819 for tattered flier 18818 (he is more amiable after a few Trumpy Tonics).  the Freeportn Groflah gives tattered flier 18819 for 18818 because he is stressed about your line of inquiry.