### PR TITLE
Update Hyrill_Pon.pl

### DIFF
--- a/freportw/Hyrill_Pon.pl
+++ b/freportw/Hyrill_Pon.pl
@@ -19,8 +19,8 @@ sub EVENT_SAY {
 }
 
 sub EVENT_ITEM {
-	#:: Match a 13863 - A Locked Book
-	if (plugin::takeItems(13863 => 1 )) {
+	#:: Match a 18010 - Torn Parchment
+	if (plugin::takeItems(18010 => 1 )) {
 		quest::say("Peh! He thinks this old skull he found is a legendary skull of Wun Toque. It is said, a wizard who possesses one is granted power and intelligence far beyond those of his peers. Yiz was searching for the skulls missing ruby eyes. It seems he found the location of the first eye. Hmm.. Lynuga.. Lynuga.. I think I have heard that name before.. Yeah! Now I remember. I met her in the Foreign Quarter of Neria.. um.. Highpass Hold. She was trying to hawk some stolen gems! I think she mumbled something about going home to Grobb. I sure don't have time to track her down.");
 		#:: Ding!
 		quest::ding();
@@ -28,7 +28,7 @@ sub EVENT_ITEM {
 		quest::faction(346, 10); 		#:: + Commons Residents
 		quest::faction(330, 2); 		#:: + Freeport Militia
 		quest::faction(281, 2); 		#:: + Knights of Truth
-		quest::faction(362, 2); 		#:: + Priests of Marr
+		quest::faction(362, 1); 		#:: + Priests of Marr
 		#:: Grant a moderate amount of experience
 		quest::exp(1000);
 	}


### PR DESCRIPTION
Hollow Skull item turn in Item reference is listed in Alla as torn parchment and this is consistent with the item received by killing A Splitpaw Assassin.  Modified the quest item accordingly.  Also made minor adjustment to faction per Alla.