### PR TITLE
Update Gindlin_Toxfodder.pl

### DIFF
--- a/qey2hh1/Gindlin_Toxfodder.pl
+++ b/qey2hh1/Gindlin_Toxfodder.pl
@@ -8,8 +8,8 @@ sub EVENT_SAY {
 }
 
 sub EVENT_ITEM {
-	#:: Match 20 gold pieces, two 14018 - Spider Venom Sac, and a 13901 - Crow's Special Brew
-	if (plugin::takeItemsCoin(0, 0, 20, 0, 14018 => 2, 13901 => 1)) {
+	#:: Match 20 gold pieces, two 14018 - Spider Venom Sac, and a 13795 - Crow's Special Brew
+	if (plugin::takeItemsCoin(0, 0, 20, 0, 14018 => 2, 13795 => 1)) {
 		quest::say("Here.  I could care less what you do with this.  Hopefully you'll lay some on the Circle of Unseen Hands.");
 		#:: Give a 14015 - Spider Venom
 		quest::summonitem(14015);


### PR DESCRIPTION
Tested with purchase from vendor "Crow" and he sells only Crow's special brew #13975, whereas he does not sell 13901 Which is a quest reward.  Alla indicates this is a purchase from the bar version, so correcting the item id