### PR TITLE
Update Enic_Ruklin.pl

### DIFF
--- a/qeynos2/Enic_Ruklin.pl
+++ b/qeynos2/Enic_Ruklin.pl
@@ -16,8 +16,8 @@ sub EVENT_SAY {
 	}
 	elsif (($text=~/donation to the temple of thunder/i) || ($text=~/donate to the temple of thunder/i)) {
 		quest::say("I would be glad to help you out. The Knights of Thunder are a respected order.");
-		#:: Give a 13292 - Donation
-		quest::summonitem(13292);
+		#:: Give a 13293 - Donation
+		quest::summonitem(13293);
 	}
 }
 


### PR DESCRIPTION
Between Kane Bayle and Enic we had a duplicate donation lore item.  The donation IDs just give #s and don't have any specific lore tied to them, so just revised the donation item # for Enic to have the missing donation ID.