### PR TITLE
Fix location in TD

### DIFF
--- a/overthere/#Translocator_Breya.pl
+++ b/overthere/#Translocator_Breya.pl
@@ -3,6 +3,6 @@ sub EVENT_SAY {
         quest::say("Hello there. There seems to be some strange problems with the boats in this area. The Academy of Arcane Sciences has sent a small team of us to investigate them. If you need to [travel to Timorous] in the meantime, I can transport you to my companion there."); 
     }
     elsif ($text=~/travel to timorous/i) {
-        quest::movepc(96, -3260.10, -4544.56, 19.47); 
+        quest::movepc(96, 3624.00, 5860.00, 1.08); 
     }
 }


### PR DESCRIPTION
Based on this report:
"Illus — 04/14/2022
after using the translocator in OT to go to TD on my gnome enchanter it spit me out at the other translocator (FV/BB) instead of the northwest spot for Sro/OT."
This fix will send to the correct translocator