### PR TITLE
Add Melee Discs upon leveling up

### DIFF
--- a/global/global_player.pl
+++ b/global/global_player.pl
@@ -136,3 +136,8 @@ sub ConvertIP {
 	my $convertedip = "$firstoctet.$secondoctet.$thirdoctet.$longip";
 	return $convertedip;
 }
+
+sub EVENT_LEVEL_UP {
+    #:: Train all disciplines, maximum set to player's level, minimum set to the level prior
+    quest::traindiscs($ulevel,$ulevel - 1);
+}


### PR DESCRIPTION
Discs across all classes have been scrubbed to ensure only those listed in the Kunark official guide will be granted upon leveling.